### PR TITLE
docs: fix Pulseaudio clone depth option

### DIFF
--- a/pulseaudio/README.md
+++ b/pulseaudio/README.md
@@ -5,7 +5,7 @@
 ### Clone repository
 #### As current stable v16.1 change pulse-version `v16.1`
 
-```$ git clone --depht=1 -b pulse-version https://github.com/pulseaudio/pulseaudio.git```
+```$ git clone --depth=1 -b pulse-version https://github.com/pulseaudio/pulseaudio.git```
 
 ### Install build dependencies, here depedencies for headless. On GUI system may different.
 ```


### PR DESCRIPTION
## Summary
- Fix the Pulseaudio README shallow-clone option from `--depht=1` to `--depth=1`.

## Validation
- Confirmed `git clone --depht=1 -b v16.1 https://github.com/pulseaudio/pulseaudio.git` fails with `unknown option 'depht=1'`.
- Confirmed the PulseAudio `v16.1` tag exists.
- Confirmed `git clone --depth=1 -b v16.1 https://github.com/pulseaudio/pulseaudio.git` completes successfully.
- Ran `rg -n 'depht|depth|pulse-version|v16\.1|git clone' pulseaudio/README.md -S`.
- Ran `git diff --check`.